### PR TITLE
Configure CORS via environment variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment variables
+DATABASE_URL=postgresql://user:password@host:port/db
+CORS_ORIGIN=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ cd agency-backend
 npm install
 ```
 
-3. Create a `.env` file with your PostgreSQL connection string:
+3. Create a `.env` file with your PostgreSQL connection string and allowed origins:
 
 ```env
 DATABASE_URL=postgresql://user:password@host:port/db
+CORS_ORIGIN=http://localhost:3000
 ```
 
 4. Push the schema to your database:
@@ -100,7 +101,7 @@ The `/reassign-access` endpoint now also accepts an array `accessIds` to move mu
 ## 🚀 Deployment with Railway
 
 * Connect this GitHub repo to your Railway project.
-* Set the `DATABASE_URL` environment variable in Railway.
+* Set the `DATABASE_URL` and `CORS_ORIGIN` environment variables in Railway.
 * Railway will auto-deploy on every `git push`.
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,20 @@
 import express from "express";
 import cors from "cors";
+import dotenv from "dotenv";
 import collaboratorsRouter from "./routes/collaborators";
 import reassignAccessRouter from "./routes/reassignAccess";
 import accessRecordsRouter from "./routes/accessRecords";
 import healthRouter from "./routes/health";
 
+dotenv.config();
+
 const app = express();
 
-app.use(cors());
+const corsOptions = process.env.CORS_ORIGIN
+  ? { origin: process.env.CORS_ORIGIN.split(",") }
+  : {};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 app.use("/collaborators", collaboratorsRouter);


### PR DESCRIPTION
## Summary
- load environment variables at startup
- allow customizing CORS origins through `CORS_ORIGIN`
- document the new env var and add `.env.example`

## Testing
- `npm run build` *(fails: cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_b_685e2125d2a88325b6365736a35dee09