### PR TITLE
Add bearer auth middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,11 @@ cd agency-backend
 npm install
 ```
 
-3. Create a `.env` file with your PostgreSQL connection string:
+3. Create a `.env` file with your PostgreSQL connection string and API token:
 
 ```env
 DATABASE_URL=postgresql://user:password@host:port/db
+API_TOKEN=your-secret-token
 ```
 
 4. Push the schema to your database:
@@ -73,6 +74,16 @@ npm run dev
 ```
 
 ---
+## 🔐 Authentication
+
+All endpoints (except `/health`) require a bearer token set via the `Authorization` header.
+
+```http
+Authorization: Bearer <your-token>
+```
+
+---
+
 
 ## API Endpoints
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,24 @@
 import express from "express";
 import cors from "cors";
+import dotenv from "dotenv";
 import collaboratorsRouter from "./routes/collaborators";
 import reassignAccessRouter from "./routes/reassignAccess";
 import accessRecordsRouter from "./routes/accessRecords";
 import healthRouter from "./routes/health";
+import authMiddleware from "./middleware/auth";
+
+dotenv.config();
 
 const app = express();
 
 app.use(cors());
 app.use(express.json());
 
+app.use("/health", healthRouter);
+app.use(authMiddleware);
 app.use("/collaborators", collaboratorsRouter);
 app.use("/reassign-access", reassignAccessRouter);
 app.use("/access-records", accessRecordsRouter);
-app.use("/health", healthRouter);
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Servidor corriendo en puerto ${PORT}`));

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction } from "express";
+
+export default function authMiddleware(req: Request, res: Response, next: NextFunction) {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Missing or invalid Authorization header" });
+  }
+
+  const token = auth.slice(7);
+  const expected = process.env.API_TOKEN;
+
+  if (!expected) {
+    console.error("API_TOKEN environment variable is not set");
+    return res.status(500).json({ error: "Server configuration error" });
+  }
+
+  if (token !== expected) {
+    return res.status(403).json({ error: "Invalid token" });
+  }
+
+  next();
+}


### PR DESCRIPTION
## Summary
- secure routes with new `auth` middleware
- load `.env` and add API token variable
- document authentication usage in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_685e2123b31c83259bf97da84f70be36